### PR TITLE
Set encoding to utf8 (Fix issue with installation)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description=(
         "Convert text to one of 27 fancy unicode representations"
     ),
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",
     packages=["fancify_text"],
     install_requires=[],


### PR DESCRIPTION
Fixed issue #2 by setting encoding to `utf8` in `setup.py`